### PR TITLE
予約を修正したい場合の挙動

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,9 +1,8 @@
 class ReservationsController < ApplicationController
   before_action :set_reservation, only: [:show, :edit]
-  before_action :authenticate_user!, only: [:new, :create] #ログインが必要なアクション名を適宜追加
+  before_action :authenticate_user!, only: [:new, :create] 
 
     def index
-      @reservations = Reservation.all
       @reservations = Reservation.all.where("day >= ?", Date.current).where("day < ?", Date.current >> 3).order(day: :desc)
     end
 
@@ -15,14 +14,14 @@ class ReservationsController < ApplicationController
         @start_time = DateTime.parse("#{@day} #{@time} JST")
       #end
       #if @reservation.save
-        #redirect_to reservation_path @reservation.id
+        #redirect_to rservation_path @reservation.id
       else
-        render :new, status: :unprocessable_entity   
+        render :new, status: :unprocessable_entity
      end
     end 
 
     def show
-      @reservation = Reservation.find(params[:id]) 
+      @reservation = Reservation.find(params[:id])
       @date = params[:day]
     end
     
@@ -40,7 +39,8 @@ class ReservationsController < ApplicationController
       end
     end
 
-   def edit
+    def edit
+      @reservation = Reservation.find(params[:id])
     end
 
     def update
@@ -61,5 +61,3 @@ class ReservationsController < ApplicationController
     @reservation = Reservation.find(params[:id])
   end
 end
-
-

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -31,4 +31,21 @@ module ReservationsHelper
     end
     return result
   end
-end
+
+
+   # def find_reservation(reservations, day, time)
+    # result = false
+    # reservations_count = reservations.count
+    # 取得した予約データにdayとtimeが一致する場合はtrue,一致しない場合はfalseを返します
+    # if reservations_count > 1
+     # reservations.each do |reservation|
+       # result = reservation[:day].eql?(day) && reservation[:time].eql?(time)
+      #  return reservation if result
+      # end
+   # elsif reservations_count == 1
+      # result = reservations[0][:day].eql?(day) && reservations[0][:time].eql?(time)
+      # return reservations[0] if result
+    # end
+   # return result
+  #end
+ end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -16,8 +16,10 @@ class Reservation < ApplicationRecord
     validate :date_three_month_end
 
     def date_before_start
-      errors.add(:day, "は過去の日付を選択できません。予約画面から正しい日付を選択してください。") if day < Date.current
-    end
+      return unless day.present?
+      errors.add(:day, "は過去の日付を選択できません。予約画面から正しい日付を選択してください。") if day.to_date < Date.current
+   end
+
 
     def date_three_month_end
       errors.add(:day, "は3ヶ月以降の日付は選択できません。予約画面から正しい日付を選択してください。") if day && ((Date.current >> 3) < day)

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -33,19 +33,33 @@
          <%= form.collection_select(:seat_type_id, SeatType.all, :id, :name, {}, {class:"select-box", id:"seat_type"}) %>
       </div>
 
+      <%= form_for @reservation do |form| %>
        <div class="day form-group">
         <%= form.label :day, '日付' %>
-        <%= form.date_field :day, class: 'form-control', value: @day %>
+        <%= form.date_field :day, class: 'form-control' %>
        </div>
        <div class="time form-group">
         <%= form.label :time, '時間' %>
-        <% if @time.nil? %>
-        <!-- @time が nil の時、何らかのデフォルト値や空欄にする -->
-        <%= form.time_field :time, class: 'form-control', value: "" %>
-        <% else %>
-        <%= form.time_field :time, class: 'form-control', value: Time.parse(@time).strftime("%H:%M") %>
-        <% end %>
+        <%= form.time_field :time, class: 'form-control', value: @reservation.time.to_s(:time) unless @reservation.time.nil? %>
        </div>
+       <div class="submit">
+        <%= form.submit value: '予約する', class: 'btn btn-primary mx-auto d-block' %>
+       </div>
+      <% end %>
+
+       <%#<div class="day form-group">%>
+        <%# form.label :day, '日付' %>
+        <%# form.date_field :day, class: 'form-control', value: @day %>
+       <%#</div>%>
+       <%#<div class="time form-group">%>
+        <%# form.label :time, '時間' %>%>
+        <%# if @time.nil? %>%>
+        <!-- @time が nil の時、何らかのデフォルト値や空欄にする -->
+        <!--%= form.time_field :time, class: 'form-control', value: "" %-->
+        <%#%> else %>
+        <!--%= form.time_field :time, class: 'form-control', value: Time.parse(@time).strftime("%H:%M") %-->
+        <%# end %>
+       <!--/div>
         <%= form.hidden_field :day, value: @day %>
         <%= form.hidden_field :time, value: @time %>
         <%= form.hidden_field :start_time, value: @start_time %>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -36,7 +36,7 @@
 
     <div class="col-12 text-right">
     <div>
-    <%= link_to '予約を修正したい場合：予約画面に戻る' , new_reservation_path(@reservation) ,class: "item-green-btn"%>
+    <%= link_to '予約を修正したい場合：前の画面に戻る' ,new_reservation_path(@reservation) ,class: "item-green-btn"%>
     </div>
     <div>
     <%= link_to '予約を完了する', reservation_orders_path(@reservation), data: {turbo: false}, class:"item-red-btn"%>


### PR DESCRIPTION
＃What
　予約を修正したい場合、新規予約画面に戻って、新たに席と日付、時間を選択しても、それらのデータはデータベースに保存　　されておらず、データを入力しているのに「〜can't be blank.」というエラーメッセージが表示されてしまうこと（データは修正前の状態で保存されている）の解消
＃Why
　主要予約機能の実装のため
