### PR TITLE
新規予約画面の挙動修正

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -9,6 +9,7 @@ class ReservationsController < ApplicationController
 
     def new
       @reservation = Reservation.new
+      @reservation.seat_type = SeatType.first
       @day = params[:day]
       @time = params[:time]
       if @day.present? && @time.present?

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <title>KORURU</title>
     <script src="https://kit.fontawesome.com/f325ea1c55.js" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="app/assets/stylesheets/reservations/new.scss">
+    <%#link rel="stylesheet" href="app/assets/stylesheets/reservations/new.scss"%>
   </head>
   
   <body class="reservations-new">
@@ -28,27 +28,23 @@
        <%= render 'devise/shared/error_messages', resource: form.object %>
       
       <div class="seat form-group">
-        <%= form.label :seat_type, '席のタイプ' %>
-        <%= form.text_field :seat_type, class: 'form-control', value: @seat_type %>
+        <%= form.label :seat_type.name, '席のタイプ' %>
+        <%= form.text_field :seat_type, class: 'form-control', value: @reservation.seat_type.name %>
          <%= form.collection_select(:seat_type_id, SeatType.all, :id, :name, {}, {class:"select-box", id:"seat_type"}) %>
       </div>
 
        <div class="day form-group">
         <%= form.label :day, '日付' %>
-        <%= form.date_field :day, class: 'form-control', value: @day %>
+        <%= form.date_field :day, class: 'form-control', value: @reservation.day %>
        </div>
-       <div class="time form-group">
+       
+      <div class="time form-group">
         <%= form.label :time, '時間' %>
-        <% if @time.nil? %>
-        <!-- @time が nil の時、何らかのデフォルト値や空欄にする -->
-        <%= form.time_field :time, class: 'form-control', value: "" %>
-        <% else %>
-        <%= form.time_field :time, class: 'form-control', value: Time.parse(@time).strftime("%H:%M") %>
-        <% end %>
-       </div>
-        <%= form.hidden_field :day, value: @day %>
-        <%= form.hidden_field :time, value: @time %>
-        <%= form.hidden_field :start_time, value: @start_time %>
+        <%= form.time_field :time, class: 'form-control', value: (@reservation.time.blank? ? "--:--" : Time.parse(@reservation.time).strftime("%H:%M")) %>
+      </div>
+        <% form.hidden_field :day, value: @reservation.day %>
+        <%  form.hidden_field :time, value: @reservation.time %>
+        <%= form.hidden_field :start_time, value: @reservation.start_time %>
        <div class="submit">
         <%= form.submit value: '予約する', class: 'btn btn-primary mx-auto d-block' %>
        </div>


### PR DESCRIPTION
# What
　・ 手のひらマークの「予約する」画面から予約できる様にするために実装を試していたが、時間と日付を入れていても、「Starttime can't be blank」というエラーメッセージが表示され、「予約する」ボタンから予約編集画面に遷移できない、という問題が生じていた。
　・上記問題を解決すべく、new.html.erbとreservation.controllerを修正すべきと考え、定義を追加したりしたが、カレンダーの「○」から空いている日を選択して新規予約も出来なくなってしまった。

＃Why
　予約アプリ実装のため。
