### PR TITLE
手のひらマークから新規予約

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -7,38 +7,40 @@ class ReservationsController < ApplicationController
       @reservations = Reservation.all.where("day >= ?", Date.current).where("day < ?", Date.current >> 3).order(day: :desc)
     end
 
-    def new
-      @reservation = Reservation.new
-      @day = params[:day]
-      @time = params[:time]
-      if @day.present? && @time.present?
-        @start_time = DateTime.parse("#{@day} #{@time} JST")
-      #end
-      #if @reservation.save
-        #redirect_to reservation_path @reservation.id
-      else
-        render :new, status: :unprocessable_entity   
-     end
-    end 
+def new
+  @reservation = Reservation.new
+  @day = params[:day]
+  @time = params[:time]
+end
 
     def show
-      @reservation = Reservation.find(params[:id]) 
+      @reservation = Reservation.find(params[:id])
       @date = params[:day]
     end
-    
-    def create
-      @reservation = current_user.reservations.build(reservation_params)
-      if @reservation.seat_type_id == 1
-        flash[:notice] = '席のタイプを選択してください。'
-        #redirect_to new_reservation_path # ユーザーを予約ページにリダイレクトします。
-      else
-        if @reservation.save
-          redirect_to reservation_path @reservation.id
-        else
-          render :new, status: :unprocessable_entity
-        end
-      end
+
+def create
+  @reservation = current_user.reservations.build(reservation_params)
+  @time = reservation_params[:time]
+
+  if @time.present?
+    begin
+      parsed_time = Time.parse(@time)
+      @reservation.start_time = DateTime.new(@reservation.day.year, @reservation.day.month, @reservation.day.day, parsed_time.hour, parsed_time.min)
+    rescue ArgumentError
+      # 無効な時刻形式の場合の処理
     end
+  end
+
+  if @reservation.seat_type_id == 1
+    flash[:notice] = '席のタイプを選択してください。'
+  else
+    if @reservation.save
+      redirect_to reservation_path(@reservation.id)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+end
 
    def edit
     end

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -9,9 +9,9 @@
     <script src="https://kit.fontawesome.com/f325ea1c55.js" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="app/assets/stylesheets/reservations/new.scss">
   </head>
-  
+
   <body class="reservations-new">
-    
+
   <div class="container">
   <div class="row">
       <div class="col-12 text-center title">
@@ -24,31 +24,34 @@
           <p><%= flash[:notice] %></p>
         </div>
        <% end %>
-       <%= form_with model: @reservation, local: true, class: 'form' do |form| %>
+       <%= form_with model: @reservation, url: reservations_path, local: true, class: 'form' do |form| %>
        <%= render 'devise/shared/error_messages', resource: form.object %>
-      
+
       <div class="seat form-group">
         <%= form.label :seat_type, '席のタイプ' %>
         <%= form.text_field :seat_type, class: 'form-control', value: @seat_type %>
          <%= form.collection_select(:seat_type_id, SeatType.all, :id, :name, {}, {class:"select-box", id:"seat_type"}) %>
       </div>
 
-       <div class="day form-group">
+      <div class="day form-group">
         <%= form.label :day, '日付' %>
         <%= form.date_field :day, class: 'form-control', value: @day %>
-       </div>
-       <div class="time form-group">
-        <%= form.label :time, '時間' %>
-        <% if @time.nil? %>
-        <!-- @time が nil の時、何らかのデフォルト値や空欄にする -->
-        <%= form.time_field :time, class: 'form-control', value: "" %>
-        <% else %>
-        <%= form.time_field :time, class: 'form-control', value: Time.parse(@time).strftime("%H:%M") %>
-        <% end %>
-       </div>
-        <%= form.hidden_field :day, value: @day %>
-        <%= form.hidden_field :time, value: @time %>
-        <%= form.hidden_field :start_time, value: @start_time %>
+      </div>
+
+<div class="time form-group">
+  <%= form.label :time, '時間' %>
+  <% if @time.present? %>
+    <% begin %>
+      <% parsed_time = Time.parse(@time) %>
+      <%= form.time_field :time, class: 'form-control', value: parsed_time.strftime("%H:%M") %>
+    <% rescue ArgumentError %>
+      <%= form.time_field :time, class: 'form-control', value: @time %>
+    <% end %>
+  <% else %>
+    <%= form.time_field :time, class: 'form-control' %>
+  <% end %>
+</div>
+
        <div class="submit">
         <%= form.submit value: '予約する', class: 'btn btn-primary mx-auto d-block' %>
        </div>


### PR DESCRIPTION
# 概要
手のひらマークからの新規予約作成機能を実装しました

# 再現手順
1. 予約一覧画面（http://localhost:3000/reservations ）に遷移
2. 手のひらマークをクリックでhttp://localhost:3000/reservations/new へ遷移
3. 席タイプ、日付、時間を設定（現在時刻より未来で）
4. 「予約する」ボタンをクリック
5. 予約確認画面（http://localhost:3000/reservations/26 など）へ遷移
6. 「予約を完了する」ボタンをクリックでhttp://localhost:3000/reservations/26/orders  へ遷移
7. 「購入確定」→「OK」クリックで予約一覧画面（http://localhost:3000/reservations ）へ戻る

# 期待する動作
予約一覧画面（http://localhost:3000/reservations ）へ戻った際に対象の予約枠が予約されていること

# 動作環境
ログイン状態で操作する